### PR TITLE
Release 0.23.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,14 +50,14 @@ SETUP_BASE = {
 
 
 REQUIREMENTS = [
-    'google-cloud-bigtable >= 0.22.0, < 0.23dev',
+    'google-cloud-bigtable >= 0.23.0, < 0.24dev',
 ]
 
 SETUP_BASE.pop('url')
 
 setup(
     name='google-cloud-happybase',
-    version='0.22.0',
+    version='0.23.0',
     description='Client library for Google Cloud Bigtable: HappyBase layer',
     long_description=README,
     url='https://github.com/GoogleCloudPlatform/google-cloud-python-happybase',


### PR DESCRIPTION
/cc @lukesneeringer

----

Release notes:

Only change: updated `google-cloud-bigtable` dependency from `0.22.x` series to `0.23.x`. (#20)

PyPI: https://pypi.python.org/pypi/google-cloud-happybase/0.23.0
