### PR TITLE
[WIP]fix: python3 compatibility about counter_inc

### DIFF
--- a/src/google/cloud/happybase/table.py
+++ b/src/google/cloud/happybase/table.py
@@ -591,7 +591,7 @@ class Table(object):
         # }
         modified_cells = row.commit()
         # Get the cells in the modified column,
-        column_cells = modified_cells[column_family_id][column_qualifier]
+        column_cells = modified_cells[column_family_id][column_qualifier.encode()]
         # Make sure there is exactly one cell in the column.
         if len(column_cells) != 1:
             raise ValueError('Expected server to return one modified cell.')

--- a/src/google/cloud/happybase/table.py
+++ b/src/google/cloud/happybase/table.py
@@ -591,7 +591,7 @@ class Table(object):
         # }
         modified_cells = row.commit()
         # Get the cells in the modified column,
-        column_cells = modified_cells[column_family_id][column_qualifier.encode()]
+        column_cells = modified_cells[column_family_id][six.b(column_qualifier)]
         # Make sure there is exactly one cell in the column.
         if len(column_cells) != 1:
             raise ValueError('Expected server to return one modified cell.')


### PR DESCRIPTION
In python3, the method `Table.counter_inc` is failed with KeyError such as below.
```
t.counter_inc('rowkey','cf1:counter')
```
```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-8-bce113a27935> in <module>()
----> 1 t.counter_inc('track','cf1:counter')

/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/google/cloud/happybase/table.py in counter_inc(self, row, column, value)
    595 
    596         # Get the cells in the modified column,
--> 597         column_cells = modified_cells[column_family_id][column_qualifier]
    598         # Make sure there is exactly one cell in the column.
    599         if len(column_cells) != 1:

KeyError: 'counter'
``` 

`modified_cells` is nested dictionary, and key of outer is typed `str`, inner is typed `bytes`.
Dictionary in python3 cannot call byte-typed-key with str, and it causes this problem.
