### PR TITLE
fix #23

### DIFF
--- a/src/google/cloud/happybase/table.py
+++ b/src/google/cloud/happybase/table.py
@@ -597,14 +597,16 @@ class Table(object):
 
         else:
             inner_keys = list(six.iterkeys(modified_cells[column_family_id]))
-            if len(inner_keys) == 0:
+            if inner_keys:
                 raise KeyError(column_qualifier)
 
             if isinstance(inner_keys[0], six.binary_type):
-                column_cells = modified_cells[column_family_id][six.b(column_qualifier)]
+                column_cells = modified_cells[
+                    column_family_id][six.b(column_qualifier)]
 
             elif isinstance(inner_keys[0], six.string_types):
-                column_cells = modified_cells[column_family_id][six.u(column_qualifier)]
+                column_cells = modified_cells[
+                    column_family_id][six.u(column_qualifier)]
 
             else:
                 raise KeyError(column_qualifier)

--- a/src/google/cloud/happybase/table.py
+++ b/src/google/cloud/happybase/table.py
@@ -597,6 +597,8 @@ class Table(object):
 
         else:
             inner_keys = list(six.iterkeys(modified_cells[column_family_id]))
+            if len(inner_keys) == 0:
+                raise KeyError(column_qualifier)
 
             if isinstance(inner_keys[0], six.binary_type):
                 column_cells = modified_cells[column_family_id][six.b(column_qualifier)]

--- a/src/google/cloud/happybase/table.py
+++ b/src/google/cloud/happybase/table.py
@@ -597,7 +597,7 @@ class Table(object):
 
         else:
             inner_keys = list(six.iterkeys(modified_cells[column_family_id]))
-            if inner_keys:
+            if not inner_keys:
                 raise KeyError(column_qualifier)
 
             if isinstance(inner_keys[0], six.binary_type):

--- a/src/google/cloud/happybase/table.py
+++ b/src/google/cloud/happybase/table.py
@@ -591,7 +591,22 @@ class Table(object):
         # }
         modified_cells = row.commit()
         # Get the cells in the modified column,
-        column_cells = modified_cells[column_family_id][column_qualifier]
+
+        if six.PY2:
+            column_cells = modified_cells[column_family_id][column_qualifier]
+
+        else:
+            inner_keys = list(six.iterkeys(modified_cells[column_family_id]))
+
+            if isinstance(inner_keys[0], six.binary_type):
+                column_cells = modified_cells[column_family_id][six.b(column_qualifier)]
+
+            elif isinstance(inner_keys[0], six.string_types):
+                column_cells = modified_cells[column_family_id][six.u(column_qualifier)]
+
+            else:
+                raise KeyError(column_qualifier)
+
         # Make sure there is exactly one cell in the column.
         if len(column_cells) != 1:
             raise ValueError('Expected server to return one modified cell.')


### PR DESCRIPTION
As the #23 shows, the method Table.counter_inc is failed with KeyError such as below.
```
t.counter_inc('rowkey','cf1:counter')
```

```
KeyError                                  Traceback (most recent call last)
<ipython-input-8-bce113a27935> in <module>()
----> 1 t.counter_inc('track','cf1:counter')

/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/google/cloud/happybase/table.py in counter_inc(self, row, column, value)
    595 
    596         # Get the cells in the modified column,
--> 597         column_cells = modified_cells[column_family_id][column_qualifier]
    598         # Make sure there is exactly one cell in the column.
    599         if len(column_cells) != 1:

KeyError: 'counter'
```

modified_cells is nested dictionary, and key of outer is typed str, inner is typed bytes.
Dictionary in python3 cannot call byte-typed-key with str, and it causes this problem.